### PR TITLE
Register the CRUDService to be available in Lambdas

### DIFF
--- a/Plugins/RawCMS.Plugins.Core/Controllers/JsLambdaController.cs
+++ b/Plugins/RawCMS.Plugins.Core/Controllers/JsLambdaController.cs
@@ -59,6 +59,7 @@ namespace RawCMS.Plugins.Core.Controllers
             engine.SetValue("input", tmpIn);
             engine.SetValue("RAWCMSRestClient", Jint.Runtime.Interop.TypeReference.CreateTypeReference(engine, typeof(JavascriptRestClient)));
             engine.SetValue("RAWCMSRestClientRequest", Jint.Runtime.Interop.TypeReference.CreateTypeReference(engine, typeof(JavascriptRestClientRequest)));
+            engine.SetValue("RAWCMSCrudService", crudService);
 
             engine.SetValue("output", tmpOut);
 

--- a/RawCMS.Library/Lambdas/JSLambdas/JSPostDeleteLambda.cs
+++ b/RawCMS.Library/Lambdas/JSLambdas/JSPostDeleteLambda.cs
@@ -21,7 +21,7 @@ namespace RawCMS.Library.Lambdas.JSLambdas
 
         public override string Description => "JSPostDeleteLambda";
 
-        public JSPostDeleteLambda(EntityService entityService) : base(entityService)
+        public JSPostDeleteLambda(EntityService entityService, CRUDService crudService) : base(entityService, crudService)
         {
         }
     }

--- a/RawCMS.Library/Lambdas/JSLambdas/JSPostSaveLambda.cs
+++ b/RawCMS.Library/Lambdas/JSLambdas/JSPostSaveLambda.cs
@@ -21,7 +21,7 @@ namespace RawCMS.Library.Lambdas.JSLambdas
 
         public override string Description => "JSPostSaveLambda";
 
-        public JSPostSaveLambda(EntityService entityService) : base(entityService)
+        public JSPostSaveLambda(EntityService entityService, CRUDService crudService) : base(entityService, crudService)
         {
         }
     }

--- a/RawCMS.Library/Lambdas/JSLambdas/JSPreDeleteLambda.cs
+++ b/RawCMS.Library/Lambdas/JSLambdas/JSPreDeleteLambda.cs
@@ -21,7 +21,7 @@ namespace RawCMS.Library.Lambdas.JSLambdas
 
         public override string Description => "JSPreDeleteLambda";
 
-        public JSPreDeleteLambda(EntityService entityService) : base(entityService)
+        public JSPreDeleteLambda(EntityService entityService, CRUDService crudService) : base(entityService, crudService)
         {
         }
     }

--- a/RawCMS.Library/Lambdas/JSLambdas/JSPreSaveLambda.cs
+++ b/RawCMS.Library/Lambdas/JSLambdas/JSPreSaveLambda.cs
@@ -21,7 +21,7 @@ namespace RawCMS.Library.Lambdas.JSLambdas
 
         public override string Description => "JSPreSaveLambda";
 
-        public JSPreSaveLambda(EntityService entityService) : base(entityService)
+        public JSPreSaveLambda(EntityService entityService, CRUDService crudService) : base(entityService, crudService)
         {
         }
     }

--- a/RawCMS.Library/Lambdas/JsDispatcher.cs
+++ b/RawCMS.Library/Lambdas/JsDispatcher.cs
@@ -23,9 +23,14 @@ namespace RawCMS.Library.Lambdas
 
         protected readonly EntityService entityService;
 
-        public JsDispatcher(EntityService entityService)
+        private readonly CRUDService crudService;
+
+        public JsDispatcher(EntityService entityService, CRUDService crudService)
         {
-            this.entityService = entityService;
+            {
+                this.entityService = entityService;
+                this.crudService = crudService;
+            }
         }
 
         public override void Execute(string collection, ref JObject item, ref Dictionary<string, object> dataContext)
@@ -44,6 +49,8 @@ namespace RawCMS.Library.Lambdas
                     Engine engine = new Engine((x) => { x.AllowClr(typeof(JavascriptRestClient).Assembly); x.AllowClr(typeof(JavascriptRestClientRequest).Assembly); });
                     engine.SetValue("RAWCMSRestClient", Jint.Runtime.Interop.TypeReference.CreateTypeReference(engine, typeof(JavascriptRestClient)));
                     engine.SetValue("RAWCMSRestClientRequest", Jint.Runtime.Interop.TypeReference.CreateTypeReference(engine, typeof(JavascriptRestClientRequest)));
+                    engine.SetValue("RAWCMSCrudService", crudService);
+
                     engine.SetValue("item", input);
                     engine.Execute(eventScript.ToString());
                     item = JObject.FromObject(input);


### PR DESCRIPTION
## Pull request content
- [X] ENHANCEMENT
- [ ] BUGFIX

**Related task:** #209 - Allow Lambdas to interact with internal data

Users can now create lambdas to interact with internal data. The registration
is different because the CRUDService doesn't have a parameterless constructor.
Instead of instantiating a CRUDService we are providing a pre-built one.

## Notes for admin
I have tested using a pretty simple example. It queries to find how many records are in the database to give the newest record an EntryNumber. I plan looking at more extensive test examples we can show to the public.

```JS
var number = RAWCMSCrudService.Count('Books', '')
item.EntryNumber = number ? number + 1 : 0
```



