### PR TITLE
 Update C# Language Version in all RawCMS Projects

### DIFF
--- a/RawCMS.Client/RawCMS.Client.csproj
+++ b/RawCMS.Client/RawCMS.Client.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RawCMS.Library/RawCMS.Library.csproj
+++ b/RawCMS.Library/RawCMS.Library.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RawCMS.Test/RawCMS.Test.csproj
+++ b/RawCMS.Test/RawCMS.Test.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/RawCMS.Test/RawCMS.Test.csproj
+++ b/RawCMS.Test/RawCMS.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RawCMS/RawCMS.csproj
+++ b/RawCMS/RawCMS.csproj
@@ -7,6 +7,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Pull request content
- [x] ENANCHEMENT
- [ ] BUGFIX

**Related task:** <https://github.com/arduosoft/RawCMS/issues/270>

No thechnical detail omitted on task

## Notes for admin
After this fix C# compiler automatically determine latest language version based on project's target framework or frameworks.This **ensures that for whatever target our project is built against, get the highest compatible language version by default.**

The latest C# compiler determines a default language version based on your project's target framework or frameworks. This is because the C# language may have features that rely on types or runtime components that are not available in every .NET implementation. 





